### PR TITLE
게시판 api 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,8 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+	implementation 'org.springframework.data:spring-data-rest-hal-explorer'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'mysql:mysql-connector-java'

--- a/fastcampus-project-board/.idea/jpa-buddy.xml
+++ b/fastcampus-project-board/.idea/jpa-buddy.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JpaBuddyIdeaProjectConfig">
+    <option name="renamerInitialized" value="true" />
+  </component>
+</project>

--- a/fastcampus-project-board/.idea/misc.xml
+++ b/fastcampus-project-board/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectType">
+    <option name="id" value="jpab" />
+  </component>
+</project>

--- a/fastcampus-project-board/.idea/vcs.xml
+++ b/fastcampus-project-board/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/fastcampus-project-board/.idea/workspace.xml
+++ b/fastcampus-project-board/.idea/workspace.xml
@@ -4,11 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="8cc4254c-a000-414e-b69b-335728ccf3c6" name="변경" comment="">
-      <change afterPath="$PROJECT_DIR$/../src/main/java/com/fastcampus/projectboard/domain/Article.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/../src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-    </list>
+    <list default="true" id="8cc4254c-a000-414e-b69b-335728ccf3c6" name="변경" comment="" />
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -94,6 +90,7 @@
       <workItem from="1664885256500" duration="14000" />
       <workItem from="1664885307059" duration="26000" />
       <workItem from="1664885655841" duration="550000" />
+      <workItem from="1665063018983" duration="15000" />
     </task>
     <servers />
   </component>

--- a/src/main/java/com/fastcampus/projectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/fastcampus/projectboard/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.fastcampus.projectboard.repository;
 
 import com.fastcampus.projectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment,Long> {
 }

--- a/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
@@ -2,6 +2,9 @@ package com.fastcampus.projectboard.repository;
 
 import com.fastcampus.projectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 //jpa repository (setter 로 이뤄진 생성자 객체와 long id 로 구분)
+
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,3 +25,4 @@ spring:
   data.rest:
     base-path: /api
     detection-strategy: annotated
+

--- a/src/test/java/com/fastcampus/projectboard/Controller/DataRestTest.java
+++ b/src/test/java/com/fastcampus/projectboard/Controller/DataRestTest.java
@@ -1,0 +1,63 @@
+package com.fastcampus.projectboard.Controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+// @WebMvcTest // Slice 테스트 (컨트롤로와 관련이 되지 않은건 로드하지 않음) 컨트롤러와 연관된 내용만 최소한으로 읽어온다.
+@DisplayName("Data Rest Test (API 테스트)")
+@Transactional //롤백 (롤맥 상태로 트랜젝션이 묶인다)
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+    // 인테그레이션 테스트 (dB에 영향을준다)
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+    @DisplayName("[api] 게시글 리스트 조회 ")
+    @Test
+    void givenNothing_whenRequestingArticles_thenReturnsArticlesJsonReponse() throws Exception {
+
+
+        //then
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+    @DisplayName("[api] 게시글 단건 조회 ")
+    @Test
+    void givenNothing_whenRequestingArticle_thenReturnsArticleJsonReponse() throws Exception {
+
+
+        //then
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글댓글  단건 조회 ")
+    @Test
+    void givenNothing_whenRequestingArticleComments_thenReturnsArticleCommentsJsonReponse() throws Exception {
+
+
+        //then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")))
+                .andDo(print());
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data Rest 로 서비스하고 해당 api 들의 존재여부만 체크하게끔 통합 테스트 작성 