### PR TITLE
#20 - 댓글 서비스 로직 구현

### DIFF
--- a/src/main/java/com/fastcampus/projectboard/Service/ArticleCommentService.java
+++ b/src/main/java/com/fastcampus/projectboard/Service/ArticleCommentService.java
@@ -1,5 +1,7 @@
 package com.fastcampus.projectboard.Service;
 
+import com.fastcampus.projectboard.domain.Article;
+import com.fastcampus.projectboard.domain.ArticleComment;
 import com.fastcampus.projectboard.dto.ArticleDto;
 import com.fastcampus.projectboard.repository.ArticleCommentRepository;
 import com.fastcampus.projectboard.repository.ArticleRepository;
@@ -7,10 +9,15 @@ import com.fastcampus.projectboard.dto.ArticleCommentDto;
 
 import com.fastcampus.projectboard.dto.ArticleWithCommentDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityNotFoundException;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+@Slf4j
 
 @RequiredArgsConstructor
 @Transactional
@@ -22,16 +29,32 @@ public class ArticleCommentService {
 
     @Transactional(readOnly = true)
     public List<ArticleCommentDto> searchArticleComments(Long articleId) {
-        return List.of();
+        List<ArticleCommentDto> articleCommentDtos = new ArrayList<>();
+        articleCommentDtos = articleCommentRepository.findByArticle_Id(articleId).stream().map(ArticleCommentDto::from).toList();
+        return articleCommentDtos;
     }
 
     public void saveArticleComment(ArticleCommentDto dto) {
+        try {
+            Article article = articleRepository.getReferenceById(dto.articleId());
+            articleCommentRepository.save(dto.toEntity(article));
+        } catch (EntityNotFoundException e) {
+            log.warn("댓글 등록 실패. 게시글을 찾을 수 없습니다 - dto: {}", dto);
+        }
     }
 
     public void updateArticleComment(ArticleCommentDto dto) {
+        try {
+            Article article = articleRepository.getReferenceById(dto.articleId());
+            ArticleComment articleComment = articleCommentRepository.getReferenceById(dto.id());
+            if (dto.content() != null) { articleComment.setContent(dto.content());}
+        } catch (EntityNotFoundException e) {
+            log.warn("댓글 업데이트 실패. 게시글을 찾을 수 없습니다 - dto: {}", dto);
+        }
     }
 
-    public void deleteArticleComment(Long articleCommentId) {
+    public void deleteArticleComment(Long Id) {
+        articleCommentRepository.deleteById(Id);
     }
 
 }


### PR DESCRIPTION
댓글 같은 경우에는 게시글에서 댓글을 불러오는게 아닌 jpa 댓글 리포에서 바로 엔티티를 가져온후에 세터를 해주면 수정이 가능하다.